### PR TITLE
Fixed checking for installation of CLI on 64 bit installs

### DIFF
--- a/Source/Scripts/deploy.ps1
+++ b/Source/Scripts/deploy.ps1
@@ -49,7 +49,7 @@ DISCLAIMER
 Add-Type -AssemblyName System.Web
 
 # Check for presence of Azure CLI
-If (-not (Test-Path -Path "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2")) {
+If (-not (Test-Path -Path "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2") -and -not (Test-Path -Path "C:\Program Files\Microsoft SDKs\Azure\CLI2")) {
     Write-Host "AZURE CLI NOT INSTALLED!`nPLEASE INSTALL THE CLI FROM https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest and re-run this script in a new PowerShell session" -ForegroundColor Red
     break
 }


### PR DESCRIPTION
Fixed an issue where deployment script flagged Azure CLI as not installed when running it on a 64 bit machine, added a new test-path statement accordingly. 