### PR TITLE
Fixed an issue where write output line was missing

### DIFF
--- a/Source/Runbooks/GetSiteTemplates.ps1
+++ b/Source/Runbooks/GetSiteTemplates.ps1
@@ -52,7 +52,8 @@ try {
   if ($siteTemplatesArr.Count -eq 1) {
     $siteTemplatesJson = "[$siteTemplatesJson]"
   }
-  
+
+  Write-Output $siteTemplatesJson
 }
 
 catch {


### PR DESCRIPTION
Runbook was not outputting the site designs due to a missing Write-Output line. This has now been reinstated. 