### PR TITLE
Bug fix for planner plan creation

### DIFF
--- a/Source/ARMTemplates/LogicApps/processprovisionrequest.json
+++ b/Source/ARMTemplates/LogicApps/processprovisionrequest.json
@@ -3551,7 +3551,7 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@triggerBody()?['SpaceType']?['Value']",
+                                                    "@triggerBody()?['SpaceTypeInternal']?['Value']",
                                                     "Microsoft Teams Team"
                                                 ]
                                             }


### PR DESCRIPTION
Updated ProcessProvisionRequest logic app to correct an issue which would cause Owners to not be added as Members if the title of the 'Microsoft Teams Team' space type was changed. Not adding Owners as Members to a team will cause the team not to appear when adding a plan to an existing team.