### PR TITLE
Bug fix where external sharing is not being configured

### DIFF
--- a/Source/ARMTemplates/LogicApps/processprovisionrequest.json
+++ b/Source/ARMTemplates/LogicApps/processprovisionrequest.json
@@ -2078,7 +2078,7 @@
                                             "defaultExternalSharingSetting": "@variables('DefaultExternalSharingSetting')",
                                             "disableDocSync": "@variables('DisableDocumentSync')",
                                             "enableAllowAccessRequests": "@variables('EnableAllowAccessRequests')",
-                                            "externalSharing": "@{triggerBody()?['ExternalSharing']}",
+                                            "externalSharing": "@triggerBody()?['ExternalSharingRequired']",
                                             "featuresToActivate": "@variables('FeaturesToActivate')",
                                             "hubSiteId": "@triggerBody()?['HubSite']",
                                             "joinHub": "@{triggerBody()?['JoinHub']}",

--- a/Source/Runbooks/ConfigureSpace.ps1
+++ b/Source/Runbooks/ConfigureSpace.ps1
@@ -92,7 +92,7 @@ function AddSiteCollectionAdmins {
 }
 
 function SetExternalSharing {
-    If ($externalSharing -eq "True") {
+    If ($externalSharing) {
 
         Write-Output "External sharing is required - configuring sharing settings"
 


### PR DESCRIPTION
Bug fix to fix an issue where external sharing was not being configured (if set to required) on a provisioned SPO site, due to the logic app using the name of an older column that has since been renamed, also requires an update to the ConfigureSpace PowerShell script.