### PR TITLE
Fixed architecture diagram mermaid syntax

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -2,7 +2,7 @@
 
 The diagram below details the architecture of the Provision Assist solution and the components used at a high level.
 
-::: mermaid
+``` mermaid
 graph TD
     A(Canvas Power App) --> | Submit data | B[(SharePoint List)] --> C(Power Automate Approval Flow) --> D(Logic App) --> E(Azure AD App) <--> | Secret stored in Key Vault | F(Azure Key Vault) --> G{Type of collaboration space} --> |SharePoint Site| H[SharePoint REST API] 
     G --> | Office 365 Group | I(Microsoft Graph)
@@ -10,5 +10,5 @@ graph TD
     I --> K(Azure Automation)
     H --> K
     J --> K
-    K --> | Additional configuration | L(PnP PowerShell) --> M(Provisioned space)
-:::
+    K --> | Additional configuration using Managed Identity | L(PnP PowerShell) --> M(Provisioned space)
+``````


### PR DESCRIPTION
Fixed the architecture diagram which was not displaying due to a syntax change in mermaid diagrams in GitHub.